### PR TITLE
Add pagination to filter inputs

### DIFF
--- a/app/admin/staff/components/data-table/StaffUserManager.tsx
+++ b/app/admin/staff/components/data-table/StaffUserManager.tsx
@@ -10,6 +10,8 @@ import { Toaster } from "@/app/components/ui/toaster";
 import { StaffUser } from "../../page";
 import { statuses } from "../../data/data";
 import axios from "axios";
+import { ColumnFilter } from "@tanstack/react-table";
+import { mapDataToStaffUsers } from "../../utils";
 
 const dataTableToolbarInputs: DataTableToolbarInput[] = [
   {
@@ -29,6 +31,16 @@ const dataTableToolbarOutputs: DataTableToolbarOption[] = [
   },
 ];
 
+const formatFilters = (filters: ColumnFilter[]): string => {
+  const formattedFilters = filters.map((filter) => {
+    return {
+      [filter.id]: filter.value,
+    };
+  });
+
+  return JSON.stringify(formattedFilters);
+};
+
 interface IStaffUserManager {
   initialStaffUsers: StaffUser[];
   totalCount: number;
@@ -42,19 +54,21 @@ const StaffUserManager = ({
   const fetchStaffUsers = async (
     pageSize: number,
     page: number,
-    increment: boolean = false
+    increment: boolean = false,
+    filters: ColumnFilter[]
   ) => {
     try {
       const params = {
         pageSize,
         page,
+        filters: formatFilters(filters),
       };
 
       const response = await axios.get("/api/admin/staff", {
         params,
       });
 
-      const newStaffUsers = response.data.staffUsers.users;
+      const newStaffUsers = mapDataToStaffUsers(response.data.staffUsers.users);
 
       if (increment) {
         setStaffUsers((prev) => [...prev, ...newStaffUsers]);
@@ -69,13 +83,16 @@ const StaffUserManager = ({
   const handlePagination = (
     pageSize: number,
     page: number,
-    increment: boolean = false
+    increment: boolean = false,
+    filters: ColumnFilter[] = []
   ) => {
     const maxEntries = pageSize * page;
     const hasMoreEntries = totalCount > staffUsers.length;
+    console.log("filters", maxEntries);
 
     if (staffUsers.length <= maxEntries && hasMoreEntries) {
-      fetchStaffUsers(pageSize, page, increment);
+      console.log("filters", filters);
+      fetchStaffUsers(pageSize, page, increment, filters);
     }
   };
 

--- a/app/admin/staff/components/data-table/StaffUserManager.tsx
+++ b/app/admin/staff/components/data-table/StaffUserManager.tsx
@@ -88,10 +88,8 @@ const StaffUserManager = ({
   ) => {
     const maxEntries = pageSize * page;
     const hasMoreEntries = totalCount > staffUsers.length;
-    console.log("filters", maxEntries);
 
     if (staffUsers.length <= maxEntries && hasMoreEntries) {
-      console.log("filters", filters);
       fetchStaffUsers(pageSize, page, increment, filters);
     }
   };

--- a/app/admin/staff/page.tsx
+++ b/app/admin/staff/page.tsx
@@ -21,7 +21,7 @@ const initialPage: number = 1;
 const initialPageSize: number = 10;
 
 async function getStaffUsers() {
-  const { users, totalCount } = await userProvider.getStaffUsers(
+  const { users, totalCount } = await userProvider.getStaffUsersWithPagination(
     initialPage,
     initialPageSize
   );

--- a/app/admin/staff/page.tsx
+++ b/app/admin/staff/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { userProvider } from "@/app/providers/userProvider";
 import StaffUserManager from "./components/data-table/StaffUserManager";
+import { mapDataToStaffUsers } from "./utils";
 
 export const metadata: Metadata = {
   title: "Staff",
@@ -15,21 +16,6 @@ export interface StaffUser {
   status: string;
   phone: string;
 }
-
-const mapDataToStaffUsers = (data: any): StaffUser[] => {
-  const staffUsers: StaffUser[] = data.map((staffUserData: any) => {
-    return {
-      id: staffUserData.id,
-      firstName: staffUserData.staffProfile?.firstname || "N/A",
-      lastName: staffUserData.staffProfile?.lastname || "N/A",
-      email: staffUserData.email,
-      status: staffUserData.status,
-      phone: staffUserData.phone,
-    };
-  });
-
-  return staffUsers;
-};
 
 const initialPage: number = 1;
 const initialPageSize: number = 10;

--- a/app/admin/staff/utils.ts
+++ b/app/admin/staff/utils.ts
@@ -1,0 +1,16 @@
+import { StaffUser } from "./page";
+
+export const mapDataToStaffUsers = (data: any): StaffUser[] => {
+  const staffUsers: StaffUser[] = data.map((staffUserData: any) => {
+    return {
+      id: staffUserData.id,
+      firstName: staffUserData.staffProfile?.firstname || "N/A",
+      lastName: staffUserData.staffProfile?.lastname || "N/A",
+      email: staffUserData.email,
+      status: staffUserData.status,
+      phone: staffUserData.phone,
+    };
+  });
+
+  return staffUsers;
+};

--- a/app/api/admin/staff/route.ts
+++ b/app/api/admin/staff/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const staffUsers = await userProvider.getStaffUsers(Number(page), Number(pageSize), filters);
+    const staffUsers = await userProvider.getStaffUsersWithPagination(Number(page), Number(pageSize), filters);
 
     return new Response(JSON.stringify({ success: true, staffUsers }));
   } catch (error) {

--- a/app/api/admin/staff/route.ts
+++ b/app/api/admin/staff/route.ts
@@ -2,9 +2,16 @@ import { staffProvider } from "@/app/providers/staffProvider";
 import { userProvider } from "@/app/providers/userProvider";
 import { NextRequest } from "next/server";
 
+export interface StaffUserPaginationFilter {
+  key: string;
+  value: string;
+}
+
 export async function GET(request: NextRequest) {
   const pageSize = request.nextUrl.searchParams.get("pageSize");
   const page = request.nextUrl.searchParams.get("page");
+  const filtersJson = request.nextUrl.searchParams.get("filters");
+  const filters = filtersJson ? JSON.parse(filtersJson) as StaffUserPaginationFilter[] : [];
 
   if (!pageSize || !page) {
     return new Response(
@@ -13,7 +20,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const staffUsers = await userProvider.getStaffUsers(Number(page), Number(pageSize));
+    const staffUsers = await userProvider.getStaffUsers(Number(page), Number(pageSize), filters);
 
     return new Response(JSON.stringify({ success: true, staffUsers }));
   } catch (error) {

--- a/app/components/data-table/data-table-faceted-filter.tsx
+++ b/app/components/data-table/data-table-faceted-filter.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { CheckIcon, PlusCircledIcon } from "@radix-ui/react-icons";
-import { Column } from "@tanstack/react-table";
+import { Column, ColumnFilter } from "@tanstack/react-table";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/app/components/ui/badge";
@@ -98,6 +98,7 @@ export function DataTableFacetedFilter<TData, TValue>({
                         selectedValues.add(option.value);
                       }
                       const filterValues = Array.from(selectedValues);
+
                       column?.setFilterValue(
                         filterValues.length ? filterValues : undefined
                       );

--- a/app/components/data-table/data-table-pagination.tsx
+++ b/app/components/data-table/data-table-pagination.tsx
@@ -4,7 +4,7 @@ import {
   DoubleArrowLeftIcon,
   DoubleArrowRightIcon,
 } from "@radix-ui/react-icons";
-import { Table } from "@tanstack/react-table";
+import { ColumnFilter, Table } from "@tanstack/react-table";
 
 import { Button } from "@/app/components/ui/button";
 import {
@@ -21,7 +21,8 @@ interface DataTablePaginationProps<TData> {
   handlePagination: (
     pageSize: number,
     page: number,
-    increment?: boolean
+    increment?: boolean,
+    filters?: ColumnFilter[]
   ) => void;
   setPageIndex: React.Dispatch<React.SetStateAction<number>>;
 }

--- a/app/components/data-table/data-table-toolbar.tsx
+++ b/app/components/data-table/data-table-toolbar.tsx
@@ -1,49 +1,105 @@
 "use client";
 
 import { Cross2Icon } from "@radix-ui/react-icons";
-import { Table } from "@tanstack/react-table";
+import { ColumnFilter, Table } from "@tanstack/react-table";
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
 import { DataTableViewOptions } from "./data-table-view-options";
 import { DataTableFacetedFilter } from "./data-table-faceted-filter";
 import { DataTableToolbarInput, DataTableToolbarOption } from "./data-table";
+import { useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 interface DataTableToolbarProps<TData> {
   dataTableToolbarOptions: DataTableToolbarOption[];
   dataTableToolbarInputs: DataTableToolbarInput[];
   table: Table<TData>;
+  handlePagination: (
+    pageSize: number,
+    page: number,
+    increment?: boolean,
+    filters?: ColumnFilter[]
+  ) => void;
 }
 
 export function DataTableToolbar<TData>({
   table,
   dataTableToolbarInputs,
   dataTableToolbarOptions,
+  handlePagination,
 }: DataTableToolbarProps<TData>) {
-  const isFiltered = table.getState().columnFilters.length > 0;
+  const columnFilters = table.getState().columnFilters;
+  const isFiltered = columnFilters.length > 0;
+  const [filters, setFilters] = useState<ColumnFilter[]>([]);
+
+  const debouncedSetFilterValue = useDebouncedCallback((column) => {
+    table.getColumn(column)?.setFilterValue(findFilterValueByColumn(column));
+    handlePagination(table.getState().pagination.pageSize, 1, false, filters);
+  }, 800);
+
+  const findFilterValueByColumn = (column: string): string => {
+    for (let filter of filters) {
+      if (filter.id === column) {
+        return filter.value as string;
+      }
+    }
+
+    return "";
+  };
+
+  const updateFilterValueByColumn = (column: string, value: string) => {
+    const currentFilter = filters.find((filter) => filter.id === column);
+
+    if (!currentFilter) {
+      setFilters((prev) => [
+        ...prev,
+        {
+          id: column,
+          value,
+        },
+      ]);
+
+      return;
+    }
+
+    const newFilters = filters.map((filter) => {
+      if (filter.id === column) {
+        return {
+          ...filter,
+          value,
+        };
+      }
+
+      return filter;
+    });
+
+    setFilters(newFilters);
+  };
 
   return (
     <div className="flex items-center justify-between">
       <div className="flex flex-1 items-center space-x-2">
-        {dataTableToolbarInputs.map(
-          (dataTableToolbarInput, index) =>
+        {dataTableToolbarInputs.map((dataTableToolbarInput, index) => {
+          return (
             table.getColumn(dataTableToolbarInput.column) && (
               <Input
                 key={`dataTableToolbarInput-${index}`}
                 placeholder={dataTableToolbarInput.placeholder}
                 value={
-                  (table
-                    .getColumn(dataTableToolbarInput.column)
-                    ?.getFilterValue() as string) ?? ""
+                  findFilterValueByColumn(dataTableToolbarInput.column) || ""
                 }
-                onChange={(event) =>
-                  table
-                    .getColumn(dataTableToolbarInput.column)
-                    ?.setFilterValue(event.target.value)
-                }
+                onChange={(event) => {
+                  debouncedSetFilterValue(dataTableToolbarInput.column);
+                  updateFilterValueByColumn(
+                    dataTableToolbarInput.column,
+                    event.target.value
+                  );
+                }}
                 className="h-8 w-[150px] lg:w-[250px]"
               />
             )
-        )}
+          );
+        })}
         {dataTableToolbarOptions &&
           dataTableToolbarOptions.map(
             (dataTableToolbarOption, index) =>
@@ -59,7 +115,16 @@ export function DataTableToolbar<TData>({
         {isFiltered && (
           <Button
             variant="ghost"
-            onClick={() => table.resetColumnFilters()}
+            onClick={() => {
+              setFilters([]);
+              handlePagination(
+                table.getState().pagination.pageSize,
+                1,
+                false,
+                []
+              );
+              table.resetColumnFilters();
+            }}
             className="h-8 px-2 lg:px-3"
           >
             Reset

--- a/app/components/data-table/data-table.tsx
+++ b/app/components/data-table/data-table.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import {
   ColumnDef,
+  ColumnFilter,
   ColumnFiltersState,
   SortingState,
   VisibilityState,
@@ -56,7 +57,8 @@ interface DataTableProps<TData, TValue> {
   handlePagination: (
     pageSize: number,
     page: number,
-    increment?: boolean
+    increment?: boolean,
+    filters?: ColumnFilter[]
   ) => void;
 }
 
@@ -123,6 +125,7 @@ export function DataTable<TData, TValue>({
         table={table}
         dataTableToolbarInputs={dataTableToolbarInputs}
         dataTableToolbarOptions={dataTableToolbarOptions}
+        handlePagination={handlePagination}
       />
       <div className="rounded-md border">
         <Table>

--- a/app/providers/userProvider.ts
+++ b/app/providers/userProvider.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { User } from "@prisma/client";
 import prisma from "@/db/prisma";
+import { StaffUserPaginationFilter } from "../api/admin/staff/route";
 
 class UserProvider {
   async createUser(data: Omit<User, "createdAt" | "updatedAt">) {
@@ -132,8 +133,23 @@ class UserProvider {
     });
   }
 
-  async getStaffUsers(page: number, pageSize: number) {
+  async getStaffUsers(page: number, pageSize: number, filters: StaffUserPaginationFilter[] = []) {
     const skip = (page - 1) * pageSize;
+
+    const filterConditions = filters.reduce((acc: any, filterObj: any) => {
+      Object.keys(filterObj).forEach(key => {
+        // Use contains for partial matching of strings
+        acc[key] = {
+          contains: filterObj[key],
+          mode: 'insensitive' // optional, for case-insensitive matching
+        };
+      });
+      return acc;
+    }, { role: 'STAFF' });
+  
+    const whereClause = {
+      ...filterConditions, // Spread the dynamically constructed filter conditions
+    };
 
     const [users, totalCount] = await prisma.$transaction([
       prisma.user.findMany({
@@ -152,9 +168,7 @@ class UserProvider {
               createdAt: true,
               updatedAt: true,
           },
-          where: {
-              role: "STAFF",
-          },
+          where: whereClause,
           skip: skip,
           take: pageSize,
       }),

--- a/app/providers/userProvider.ts
+++ b/app/providers/userProvider.ts
@@ -133,7 +133,7 @@ class UserProvider {
     });
   }
 
-  async getStaffUsers(page: number, pageSize: number, filters: StaffUserPaginationFilter[] = []) {
+  async getStaffUsersWithPagination(page: number, pageSize: number, filters: StaffUserPaginationFilter[] = []) {
     const skip = (page - 1) * pageSize;
 
     const filterConditions = filters.reduce((acc: any, filterObj: any) => {

--- a/app/staff/[id]/profile/components/MultiStepForm.tsx
+++ b/app/staff/[id]/profile/components/MultiStepForm.tsx
@@ -91,7 +91,6 @@ const MultiStepForm: React.FC<MultiStepFormProps> = ({
   const [currentStep, setCurrentStep] = useState<number>(0);
   const [formData, setFormData] = useState<StaffProfile | null>(profile);
   const router = useRouter();
-
   const isInitialSetup = profile?.profileSetupComplete === true ? false : true;
 
   const CurrentStepComponent = steps[currentStep].component;

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "ts-jest": "^29.1.2",
         "twilio": "^5.1.0",
         "typescript": "5.0.4",
+        "use-debounce": "^10.0.1",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -12140,6 +12141,17 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.1.tgz",
+      "integrity": "sha512-0uUXjOfm44e6z4LZ/woZvkM8FwV1wiuoB6xnrrOmeAEjRDDzTLQNRFtYHvqUsJdrz1X37j0rVGIVp144GLHGKg==",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ts-jest": "^29.1.2",
     "twilio": "^5.1.0",
     "typescript": "5.0.4",
+    "use-debounce": "^10.0.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Pagination key points:

Api initially fetches 10 most recent entries

Going to next page or/and increasing the page row limit fetches for new entries IF all entries have not already been fetched. (if all entries have already been fetched, there wont be any more api calls to fetch additional entries)

Going to previous page (or decreasing the table row count) and going back to next page (or increasing total row count) does not refetch entries.

Filtering fetches all entries that match filter logic (unless all entries have already been fetched)