### PR TITLE
fixed bugs in admin staff page

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -29,8 +29,17 @@ export async function POST(request: Request) {
   const body: RequestBody = await request.json();
 
   try {
-    const user = await userProvider.updateUserStatus(body.id, body.status);
+    const user = await userProvider.getUser(body.id);
+    if (!user) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Could not find the user in the system",
+        })
+      );
+    }
     const userProfileName = await getUserProfileName(body.id, user.role);
+    await userProvider.updateUserStatus(body.id, body.status);
 
     if (body.status === "APPROVED") {
       await emailProvider.sendEmailWithTemplate({

--- a/app/providers/userProvider.ts
+++ b/app/providers/userProvider.ts
@@ -193,6 +193,7 @@ class UserProvider {
       prisma.user.count({
         where: {
           role: "STAFF",
+          archived: false,
         },
       }),
     ]);


### PR DESCRIPTION
Fixed a couple bugs on the Admin staff profile 
- when the pagination is happening the userCount was also counting the archived users bringing an incorrect count which made the last page populate twice if the user paginate back a page then forward again
- when an admin approves a staff user and the staff user did not create their profile and sign any contract yet, the approval goes through however an error happens when the approval email is being sent to the staff user because the user profile is needed to construct the email. It is fixed now to throw an error if the user does not have a profile yet